### PR TITLE
Fix: import used linter rule 

### DIFF
--- a/internal/lint/rules/import_used.go
+++ b/internal/lint/rules/import_used.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/yoheimuta/go-protoparser/v4/parser"
@@ -21,19 +20,23 @@ func (i ImportUsed) Validate(protoInfo lint.ProtoInfo) []error {
 	imports := make(map[string]bool)
 	importInfo := make(map[string]*parser.Import)
 	for _, imp := range protoInfo.Info.ProtoBody.Imports {
-		pkgName := filepath.Dir(imp.Location)
-		pkgName = strings.Trim(pkgName, "\"")
+		pkgName := i.formatImportName(imp.Location)
 		imports[pkgName] = false
 		importInfo[pkgName] = imp
 	}
 
 	for _, msg := range protoInfo.Info.ProtoBody.Messages {
 		for _, field := range msg.MessageBody.Fields {
-			replaced := strings.ReplaceAll(field.Type, ".", "/")
-			key := filepath.Dir(replaced)
-			key = strings.Trim(key, "\"")
+			key := i.formatField(field.Type)
 			if _, ok := imports[key]; ok {
 				imports[key] = true
+			}
+
+			for i2 := range field.FieldOptions {
+				key = i.formatOption(field.FieldOptions[i2].OptionName)
+				if _, ok := imports[key]; ok {
+					imports[key] = true
+				}
 			}
 		}
 	}
@@ -49,4 +52,28 @@ func (i ImportUsed) Validate(protoInfo lint.ProtoInfo) []error {
 	}
 
 	return res
+}
+
+func (i ImportUsed) formatImportName(input string) string {
+	importName := strings.Trim(input, "\"")
+	importName = strings.ToLower(importName)
+
+	return importName
+}
+
+func (i ImportUsed) formatField(input string) string {
+	field := strings.ReplaceAll(input, ".", "/")
+	field = i.formatImportName(field)
+	field += ".proto"
+
+	return field
+}
+
+func (i ImportUsed) formatOption(input string) string {
+	option := strings.ReplaceAll(input, "(", "")
+	option = strings.ReplaceAll(option, ")", "")
+	option = i.formatField(option)
+
+	return option
+
 }

--- a/internal/lint/rules/import_used.go
+++ b/internal/lint/rules/import_used.go
@@ -62,17 +62,26 @@ func (i ImportUsed) formatImportName(input string) string {
 }
 
 func (i ImportUsed) formatField(input string) string {
+	// replacing . with / to match the import name
 	field := strings.ReplaceAll(input, ".", "/")
-	field = i.formatImportName(field)
+	field = strings.Trim(field, "\"")
+	field = strings.ToLower(field)
+	// adding .proto to match the import name file
 	field += ".proto"
 
 	return field
 }
 
 func (i ImportUsed) formatOption(input string) string {
+	// removing the parenthesis from option
 	option := strings.ReplaceAll(input, "(", "")
 	option = strings.ReplaceAll(option, ")", "")
-	option = i.formatField(option)
+	// replacing . with / to match the import name
+	option = strings.ReplaceAll(option, ".", "/")
+	option = strings.Trim(option, "\"")
+	option = strings.ToLower(option)
+	// adding .proto to match the import name file
+	option += ".proto"
 
 	return option
 

--- a/internal/lint/rules/import_used_test.go
+++ b/internal/lint/rules/import_used_test.go
@@ -19,6 +19,10 @@ func TestImportUsed_Validate(t *testing.T) {
 			fileName: invalidAuthProto,
 			wantErr:  lint.ErrImportIsNotUsed,
 		},
+		"invalid_partial_import": {
+			fileName: invalidsSessionProto,
+			wantErr:  lint.ErrImportIsNotUsed,
+		},
 		"valid": {
 			fileName: validAuthProto,
 			wantErr:  nil,

--- a/internal/lint/rules/init_test.go
+++ b/internal/lint/rules/init_test.go
@@ -17,6 +17,7 @@ const (
 	invalidAuthProto3        = `./../../../testdata/auth/InvalidName.proto`
 	invalidAuthProto4        = `./../../../testdata/invalid_pkg/queue.proto`
 	invalidAuthProtoEmptyPkg = `./../../../testdata/auth/empty_pkg.proto`
+	invalidsSessionProto     = `./../../../testdata/invalid_pkg/session.proto`
 	validAuthProto           = `./../../../testdata/api/session/v1/session.proto`
 	validAuthProto2          = `./../../../testdata/api/session/v1/events.proto`
 )
@@ -32,6 +33,7 @@ func start(t testing.TB) (*require.Assertions, map[string]lint.ProtoInfo) {
 		invalidAuthProto3:        parseFile(t, assert, invalidAuthProto3),
 		invalidAuthProto4:        parseFile(t, assert, invalidAuthProto4),
 		invalidAuthProtoEmptyPkg: parseFile(t, assert, invalidAuthProtoEmptyPkg),
+		invalidsSessionProto:     parseFile(t, assert, invalidsSessionProto),
 		validAuthProto:           parseFile(t, assert, validAuthProto),
 		validAuthProto2:          parseFile(t, assert, validAuthProto2),
 	}

--- a/testdata/invalid_pkg/session.proto
+++ b/testdata/invalid_pkg/session.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package api.session.v1;
 
-import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/some.proto";
 
 option go_package = "github.com/ZergsLaw/back-template/api/session/v1;pb";
 
@@ -28,7 +28,7 @@ message GetRequest {
 //---Must be filled out---
 message GetResponse {
   // Contains session's UUID.
-  string session_id = 1 [(google.api.field_behavior) = REQUIRED];
+  string session_id = 1;
   // Contains user's UUID.
   string user_id = 2;
   // Contains user's session start time.


### PR DESCRIPTION
Fix: import used linter rule for parsing field options and checking imports not only by path, but by file as well