### PR TITLE
WIP: feat: Modify download command behaviour

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/easyp-tech/easyp
 
-go 1.22
+go 1.23
 
 require (
 	github.com/brianvoe/gofakeit/v6 v6.28.0


### PR DESCRIPTION
For now `download` command uses only `easyp.yaml` config for installing deps.
This PR offers change this behaviour.
1. Try to read `easyp.lock` file
2. if it's empty or doesn't exist -> use `easyp.yaml`
3. If it exists -> install versions which declared there