### PR TITLE
generation with defined root

### DIFF
--- a/internal/api/temporaly_helper.go
+++ b/internal/api/temporaly_helper.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/samber/lo"
 
@@ -106,6 +107,14 @@ func buildCore(_ context.Context, cfg config.Config, dirWalker core.DirWalker) (
 			}), func(i core.InputGitRepo, _ int) bool {
 				return i.URL != ""
 			}),
+			InputFilesDir: lo.Filter(lo.Map(cfg.Generate.Inputs, func(i config.Input, _ int) core.InputFilesDir {
+				return core.InputFilesDir{
+					Path: i.InputFilesDir.Path,
+					Root: i.InputFilesDir.Root,
+				}
+			}), func(i core.InputFilesDir, _ int) bool {
+				return i.Path != "" && IsExistingDir(i.Root)
+			}),
 		},
 		console.New(),
 		store,
@@ -116,4 +125,24 @@ func buildCore(_ context.Context, cfg config.Config, dirWalker core.DirWalker) (
 	)
 
 	return app, nil
+}
+
+func IsExistingDir(path string) bool {
+	if path == "" || strings.ContainsRune(path, '\x00') {
+		return false
+	}
+
+	// Очистим путь от лишнего (типа "./../")
+	cleanPath := filepath.Clean(path)
+
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return false
+	}
+
+	if !info.IsDir() {
+		return false
+	}
+
+	return true
 }

--- a/internal/api/temporaly_helper.go
+++ b/internal/api/temporaly_helper.go
@@ -93,11 +93,6 @@ func buildCore(_ context.Context, cfg config.Config, dirWalker core.DirWalker) (
 			}
 		}),
 		core.Inputs{
-			Dirs: lo.Filter(lo.Map(cfg.Generate.Inputs, func(i config.Input, _ int) string {
-				return i.Directory
-			}), func(s string, _ int) bool {
-				return s != ""
-			}),
 			InputGitRepos: lo.Filter(lo.Map(cfg.Generate.Inputs, func(i config.Input, _ int) core.InputGitRepo {
 				return core.InputGitRepo{
 					URL:          i.GitRepo.URL,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,9 @@ type Generate struct {
 
 // Input source for generating code.
 type Input struct {
-	Directory string       `yaml:"directory"`
-	GitRepo   InputGitRepo `yaml:"git_repo"`
+	Directory     string        `yaml:"directory"`
+	GitRepo       InputGitRepo  `yaml:"git_repo"`
+	InputFilesDir InputFilesDir `yaml:"input_files_dir"`
 }
 
 // InputGitRepo is the configuration of the git repository.
@@ -40,6 +41,12 @@ type InputGitRepo struct {
 // InputDirectory is the configuration of the directory.
 type InputDirectory struct {
 	Path string `yaml:"path"`
+}
+
+// InputFilesDir is the configuration of the directory with additional functionality.
+type InputFilesDir struct {
+	Path string `yaml:"path"`
+	Root string `yaml:"root"`
 }
 
 // Config is the configuration of easyp.

--- a/internal/core/dom.go
+++ b/internal/core/dom.go
@@ -221,11 +221,16 @@ type (
 		SubDirectory string
 		Out          string
 	}
-
+	// InputFilesDir is the configuration of the directory with additional functionality.
+	InputFilesDir struct {
+		Path string
+		Root string
+	}
 	// Inputs is the source for generating code.
 	Inputs struct {
 		Dirs          []string
 		InputGitRepos []InputGitRepo
+		InputFilesDir []InputFilesDir
 	}
 	// Config is the configuration for EasyP generate.
 	Config struct {

--- a/internal/core/dom.go
+++ b/internal/core/dom.go
@@ -228,9 +228,8 @@ type (
 	}
 	// Inputs is the source for generating code.
 	Inputs struct {
-		Dirs          []string
-		InputGitRepos []InputGitRepo
 		InputFilesDir []InputFilesDir
+		InputGitRepos []InputGitRepo
 	}
 	// Config is the configuration for EasyP generate.
 	Config struct {

--- a/internal/core/generate.go
+++ b/internal/core/generate.go
@@ -126,35 +126,12 @@ func (c *Core) Generate(ctx context.Context, root, directory string) error {
 			return fmt.Errorf("fsWalker.WalkDir: %w", err)
 		}
 	}
-	fsWalker := fs.NewFSWalker(directory, "")
-
-	err := fsWalker.WalkDir(func(path string, err error) error {
-		switch {
-		case err != nil:
-			return err
-		case ctx.Err() != nil:
-			return ctx.Err()
-		case filepath.Ext(path) != ".proto":
-			return nil
-		case shouldIgnore(path, c.inputs.Dirs):
-			c.logger.DebugContext(ctx, "ignore", slog.String("path", path))
-
-			return nil
-		}
-
-		q.Files = append(q.Files, path)
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("fsWalker.WalkDir: %w", err)
-	}
 
 	cmd := q.build()
 
 	slog.DebugContext(ctx, "Run command", "cmd", cmd)
 
-	_, err = c.console.RunCmd(ctx, root, cmd)
+	_, err := c.console.RunCmd(ctx, root, cmd)
 	if err != nil {
 		return fmt.Errorf("adapters.RunCmd: %w", err)
 	}


### PR DESCRIPTION
Например. Мы хотим назначить корневой директорией генерации какую-то папку, чтобы импорты прописывать уже относительно неё. Тогда можно в конфиге сделать такой  `input`
```yaml
    - input_files_dir:
        path: "."
        root: "api/server"
````
такой `input` будет смотреть все файлы в директории "api/server", а импорты файлов внутри этой директории могут выглядеть так:
```.proto
import "types.proto";
```