### PR TITLE
fix: empty value in plugin options

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,9 @@ func (d *InputFilesDir) UnmarshalYAML(value *yaml.Node) error {
 			return err
 		}
 		*d = InputFilesDir(r)
+		if d.Root == "" {
+			d.Root = "."
+		}
 	default:
 		return fmt.Errorf("unsupported type for directory: %v", value.Kind)
 	}

--- a/internal/core/dom.go
+++ b/internal/core/dom.go
@@ -273,6 +273,10 @@ func (q Query) build() string {
 		buf.WriteString("_opt=")
 
 		options := lo.MapToSlice(plugin.Options, func(k string, v string) string {
+			if v == "" {
+				return k
+			}
+
 			return k + "=" + v
 		})
 		buf.WriteString(strings.Join(options, ","))


### PR DESCRIPTION
Например, нам нужно сформировать опции плагинам таким образом, чтобы была опция без значения:
```
protoc -I . --python_betterproto_opt=pydantic_dataclasses --python_betterproto_out=lib example.proto
```

Сейчас это происходит с багом, вот так:
```
protoc -I . --python_betterproto_opt=pydantic_dataclasses= --python_betterproto_out=lib example.proto
```

Данный ПР фиксит этот баг