### PR TITLE
fix: override AgainstGitRef via config

### DIFF
--- a/internal/api/breaking_check.go
+++ b/internal/api/breaking_check.go
@@ -95,7 +95,7 @@ func (b BreakingCheck) action(ctx *cli.Context) error {
 
 	path := ctx.String(flagLintDirectoryPath.Name)
 	against := ctx.String(flagAgainstBranchName.Name)
-	if against != "" {
+	if cfg.BreakingCheck.AgainstGitRef == "" {
 		cfg.BreakingCheck.AgainstGitRef = against
 	}
 


### PR DESCRIPTION
The variable `against` always contains `master`, so it’s not possible to override `against_git_ref` via the configuration.