### PR TITLE
bug: fix input path on Windows

### DIFF
--- a/internal/fs/fs/dir_walker.go
+++ b/internal/fs/fs/dir_walker.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 type FS interface {
@@ -15,6 +16,9 @@ func NewFSWalker(root, path string) *FSWalker {
 	if path == "" {
 		path = "."
 	}
+
+	// os.DirFS always expects forward slashes, even on Windows
+	path = filepath.ToSlash(path)
 
 	diskFS := os.DirFS(root)
 	return &FSWalker{


### PR DESCRIPTION
Fix input path on Windows

Currently, this configuration does not work on Windows:

```
generate:
  inputs:
    - directory: "contracts/def"
```

The changes in this PR will add support for this configuration.