### PR TITLE
(Suggestion) Fix imports order before compilation

### DIFF
--- a/internal/core/generate.go
+++ b/internal/core/generate.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/bufbuild/protocompile"
@@ -20,7 +21,6 @@ import (
 	pluginexecutor "github.com/easyp-tech/easyp/internal/adapters/plugin"
 	"github.com/easyp-tech/easyp/internal/core/models"
 	"github.com/easyp-tech/easyp/internal/fs/fs"
-	"slices"
 )
 
 // Generate generates files.


### PR DESCRIPTION
### Summary

This PR addresses a suggestion to fix where `easyp generate` prioritizes remote dependencies over local files when they share the same directory structure. This leads to "shadowing," where the generator uses a `proto`-file from a downloaded dependency instead of a local one with the same path. 

Currently, the `easyp generate` command processes imports and directories in a fixed order:

- Lock file dependencies
- Remote repositories
- Local inputs

Because remote dependencies are processed first, any local file that mimics the path of a dependency (e.g., `buf/validate/validate.proto`) is ignored in favor of the remote version. This makes it impossible to override or mock specific `proto`-definitions locally without changing the project structure.

### Steps to reproduce

1. Project structure:

```
.
├── buf
│   └── validate
│       └── validate.proto  <-- My local custom file
├── easyp.yaml
└── go.mod
```

2. Local `buf/validate/validate.proto` content:

```
syntax = "proto3";
package hello.go;

message Ahoj {
  int64 id = 1;
}
```

3. Configuration (`easyp.yaml`):

```
deps:
  - github.com/protocolbuffers/protobuf-go@v1.36.11
  - github.com/bufbuild/protovalidate@v1.1.0 # <-- This also contains buf/validate/validate.proto

generate:
  inputs:
    - directory: '.'
  plugins:
    - path: go
      out: ./pkg
      opts:
        paths: source_relative
```

4. Execution:

```
./.bin/easyp mod download
./.bin/easyp generate
```

**Actual Result**: The generated file `pkg/buf/validate/validate.pb.go` contains the code from `protovalidate` (remote), not from the local `Ahoj` message.

```
// Code generated by protoc-gen-go. DO NOT EDIT.
// source: buf/validate/validate.proto
package validate
// ... (contains remote Buf Technologies definitions instead of local ones)
```

**Expected Result**: The generator should prioritize the local file, resulting in a generated package `hello_go` with the `Ahoj` message.

### Future suggested Solution:

`local-first` option - **but I think that this is rare situation when need to process remote dependencies first**. Example:

```
generate:
  local-first: true
  inputs:
    - directory: "api"

```

### Testing

- [x] Manual verification with the reproduction steps above.
