### PR TITLE
Added support for http:// fetching dependencies and explicit schema i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ easyp.lock
 node_modules
 *.tsbuildinfo
 .rules-mcp
+
+.vscode

--- a/example.easyp.yaml
+++ b/example.easyp.yaml
@@ -6,13 +6,10 @@ lint:
     - COMMENT_SERVICE
     - IMPORT_USED
 deps:
-#  - github.com/googleapis/googleapis
-#  - github.com/googleapis/googleapis@common-protos-1_3_1
-#  - github.com/googleapis/googleapis@27156597fdf4fb77004434d4409154a230dc9a32
-#  - github.com/googleapis/googleapis@eae19435eb84f8f7a78000858432b64455525ee7
-  #
-#  - github.com/bufbuild/protovalidate@v0.3.1
-#  - github.com/grpc-ecosystem/grpc-gateway@v2.19.1
+  - https://github.com/googleapis/googleapis        # explicit https://
+  - http://corp.gitlab.com/repository@v1.0.0        # http:// instead of https://
+  - github.com/bufbuild/protovalidate@v0.3.1        # https:// by default
+  - github.com/grpc-ecosystem/grpc-gateway@v2.19.1  # https:// by default
 
 breaking:
   ignore:

--- a/internal/adapters/repository/git/git.go
+++ b/internal/adapters/repository/git/git.go
@@ -44,10 +44,10 @@ type Console interface {
 }
 
 // New returns gitRepo instance
-// remote: full remoteURL address without schema
+// remote: full remoteURL address with schema
 func New(ctx context.Context, remote string, cacheDir string, console Console) (repository.Repo, error) {
 	r := &gitRepo{
-		remoteURL: getRemote(remote),
+		remoteURL: remote,
 		cacheDir:  cacheDir,
 		console:   console,
 	}
@@ -69,9 +69,9 @@ func New(ctx context.Context, remote string, cacheDir string, console Console) (
 	return r, nil
 }
 
-func getRemote(name string) string {
-	return "https://" + name
-}
+// func getRemote(name string) string {
+// 	return "https://" + name
+// }
 
 // getCommitDatetime returns datetime of commit
 // NOTE: the commit has to be fetched!

--- a/internal/core/get.go
+++ b/internal/core/get.go
@@ -12,7 +12,7 @@ import (
 
 // Get download package.
 func (c *Core) Get(ctx context.Context, requestedModule models.Module) error {
-	log := c.logger.With(slog.String("module", requestedModule.Name), slog.String("version", string(requestedModule.Version)))
+	log := c.logger.With(slog.String("schema", requestedModule.Schema), slog.String("module", requestedModule.Name), slog.String("version", string(requestedModule.Version)))
 	cacheDownloadPaths := c.storage.GetCacheDownloadPaths(requestedModule.Name, string(requestedModule.Version))
 
 	var installedModuleInfo models.InstalledModuleInfo
@@ -56,7 +56,7 @@ func (c *Core) get(ctx context.Context, requestedModule models.Module) (models.I
 		return models.InstalledModuleInfo{}, fmt.Errorf("c.storage.CreateCacheRepositoryDir: %w", err)
 	}
 	// TODO: use factory (git, svn etc)
-	repo, err := git.New(ctx, requestedModule.Name, cacheRepositoryDir, c.console)
+	repo, err := git.New(ctx, requestedModule.Schema+requestedModule.Name, cacheRepositoryDir, c.console)
 	if err != nil {
 		return models.InstalledModuleInfo{}, fmt.Errorf("git.New: %w", err)
 	}
@@ -81,7 +81,7 @@ func (c *Core) get(ctx context.Context, requestedModule models.Module) (models.I
 		return models.InstalledModuleInfo{}, fmt.Errorf("c.moduleConfig.Read: %w", err)
 	}
 
-	log := c.logger.With(slog.String("module", requestedModule.Name), slog.String("version", string(requestedModule.Version)))
+	log := c.logger.With(slog.String("module", requestedModule.Schema+requestedModule.Name), slog.String("version", string(requestedModule.Version)))
 
 	for _, indirectDep := range moduleConfig.Dependencies {
 		if err := c.Get(ctx, indirectDep); err != nil {

--- a/internal/core/models/module.go
+++ b/internal/core/models/module.go
@@ -30,8 +30,9 @@ var (
 	ErrRequestedVersionNotGenerated = errors.New("requested version is not generated")
 )
 
-// Module contain requested dependency name and its version
+// Module contain requested dependency schema, name and its version
 type Module struct {
+	Schema  string           // schema to request remote repository (e.g. http:// https://)
 	Name    string           // Full path on remote repository
 	Version RequestedVersion // Version obtained from config (Omitted if version was omitted)
 }
@@ -48,9 +49,20 @@ type GeneratedVersionParts struct {
 	CommitHash string
 }
 
-// NewModule create Module struct from raw dependency string: remote@version
-// dependency string format: origin@version: github.com/company/repository@v1.2.3
+// NewModule create Module struct from raw dependency string: schema://remote@version
+//
+// dependency string format: [schema://]origin@version: https://github.com/company/repository@v1.2.3
+//
+// If schema is not speciefied, https:// is by default.
 func NewModule(dependency string) Module {
+	schema := "https://" // Default schema
+
+	if strings.Contains(dependency, "://") {
+		schemaEnd := strings.Index(dependency, "://") + 3
+		schema = dependency[:schemaEnd]
+		dependency = dependency[schemaEnd:]
+	}
+
 	parts := strings.Split(dependency, "@")
 	name := parts[0]
 	version := Omitted // by default set version as Omitted
@@ -58,6 +70,7 @@ func NewModule(dependency string) Module {
 		version = RequestedVersion(parts[1])
 	}
 	return Module{
+		Schema:  schema,
 		Name:    name,
 		Version: version,
 	}

--- a/internal/core/models/module_test.go
+++ b/internal/core/models/module_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NewModule(t *testing.T) {
+func Test_NewModule_Versions(t *testing.T) {
 	tests := map[string]struct {
 		dependency     string
 		expectedResult Module
@@ -14,6 +14,7 @@ func Test_NewModule(t *testing.T) {
 		"with version": {
 			dependency: "github.com/company/repository@v1.2.3",
 			expectedResult: Module{
+				Schema:  "https://",
 				Name:    "github.com/company/repository",
 				Version: "v1.2.3",
 			},
@@ -21,6 +22,55 @@ func Test_NewModule(t *testing.T) {
 		"without version": {
 			dependency: "github.com/company/repository",
 			expectedResult: Module{
+				Schema:  "https://",
+				Name:    "github.com/company/repository",
+				Version: Omitted,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			result := NewModule(tc.dependency)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func Test_NewModule_Schemas(t *testing.T) {
+	tests := map[string]struct {
+		dependency     string
+		expectedResult Module
+	}{
+		"without schema": {
+			dependency: "github.com/company/repository",
+			expectedResult: Module{
+				Schema:  "https://",
+				Name:    "github.com/company/repository",
+				Version: Omitted,
+			},
+		},
+		"with http://": {
+			dependency: "http://github.com/company/repository",
+			expectedResult: Module{
+				Schema:  "http://",
+				Name:    "github.com/company/repository",
+				Version: Omitted,
+			},
+		},
+		"with https://": {
+			dependency: "https://github.com/company/repository",
+			expectedResult: Module{
+				Schema:  "https://",
+				Name:    "github.com/company/repository",
+				Version: Omitted,
+			},
+		},
+		"with unexpected_scheme://": {
+			dependency: "unexpected_scheme://github.com/company/repository",
+			expectedResult: Module{
+				Schema:  "unexpected_scheme://",
 				Name:    "github.com/company/repository",
 				Version: Omitted,
 			},

--- a/internal/core/update.go
+++ b/internal/core/update.go
@@ -21,7 +21,7 @@ func (c *Core) Update(ctx context.Context, dependencies []string) error {
 
 	for _, dependency := range dependencies {
 		module := models.NewModule(dependency)
-		log := c.logger.With(slog.String("module", module.Name), slog.String("version", string(module.Version)))
+		log := c.logger.With(slog.String("schema", module.Schema), slog.String("module", module.Name), slog.String("version", string(module.Version)))
 
 		log.Debug(ctx, "updating dependency")
 


### PR DESCRIPTION
# Problems
## 1. HTTP support
There was no support for downloading dependencies over HTTP, as described in open issue #134.

## 2. Explicit schema indication
EasyP [docs](https://easyp.tech/docs/guide/cli/generator/generator) says that it is correct to write this way in `easyp.yaml`:
```yaml
generate:
  inputs:
    - directory: 
        path: "proto"
        root: "."
    
    - git_repo:
        url: "github.com/acme/weather@v1.2.3"
        sub_directory: "proto/api"

    - git_repo:
        url: "https://github.com/company/internal-protos.git" # incorrect explicit schema indication https://
        sub_directory: "definitions" 
```

Example `easyp.yaml` config:
```yaml
# EasyP configuration file.
# Documentation: https://easyp.tech/docs/guide/introduction/what-is

lint:
  use:
    # Minimal
    ...

deps:
  - https://github.com/bufbuild/protoc-gen-validate@v1.3.3 # explicit https://

breaking:
  against_git_ref: master
```

Output:
```bash
$ easyp mod update 
time=2026-03-05T21:13:33.347+03:00 level=INFO msg="updating dependencies" count=1
time=2026-03-05T21:13:44.909+03:00 level=ERROR msg="version not found" module=https://github.com/bufbuild/protoc-gen-validate version=v1.3.
```

# Solution
## 1. HTTP support
Now the user can explicitly specify this in `easyp.yaml`:
```yaml
# deps section
deps:
  - http://corp.gitlab.com/repository@v1.0.0        # http:// instead of https://

generate:
  inputs:
    - git_repo:
        url: "http://corp.gitlab.com/contracts@v1.1.0" # remote protos 
```

## 2. Explicit schema indication
Now it is correct to explicit indicate schema:
```yaml
deps:
  - https://github.com/googleapis/googleapis        # explicit https://
  - http://corp.gitlab.com/repository@v1.0.0        # http:// instead of https://
  - github.com/bufbuild/protovalidate@v0.3.1        # https:// by default
  - github.com/grpc-ecosystem/grpc-gateway@v2.19.1  # https:// by default
```
If no scheme is specified, https:// is used by default.

# Impact on dependency storage in `~/.easyp/mod`

There are no any changes to storing deps in `.easyp/mod` (there is no `http:/` or `https:/` folders in `~/.easyp/mod`).

The scheme only affects the way dependencies are downloaded.