### PR TITLE
Fix descriptor set build

### DIFF
--- a/internal/core/generate.go
+++ b/internal/core/generate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bufbuild/protocompile/protoutil"
 	"github.com/bufbuild/protocompile/wellknownimports"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 
@@ -156,34 +157,27 @@ func (c *Core) Generate(ctx context.Context, root, directory, descriptorSetOut s
 	dependencyFiles := make([]string, 0)
 
 	// Recursive function to add file and its dependencies in correct order
-	var addFileWithDeps func(string) error
-	addFileWithDeps = func(fileName string) error {
+	var addFileWithDeps func(protoreflect.FileDescriptor) error
+	addFileWithDeps = func(file protoreflect.FileDescriptor) error {
+		fileName := file.Path()
 		// If already processed - skip
 		if processedFiles[fileName] {
 			return nil
 		}
 
-		// Compile file
-		depRes, err := compiler.Compile(ctx, fileName)
-		if err != nil {
-			return fmt.Errorf("compile %s: %w", fileName, err)
-		}
-
-		if len(depRes) == 0 {
-			return fmt.Errorf("no results for %s", fileName)
-		}
-
-		descriptor := protoutil.ProtoFromFileDescriptor(depRes[0])
-
 		// IMPORTANT: first recursively add all dependencies
-		for _, dep := range descriptor.Dependency {
+		for i := range file.Imports().Len() {
+			dep := file.Imports().Get(i)
+
 			if err := addFileWithDeps(dep); err != nil {
 				// Ignore errors for optional dependencies
 				c.logger.Warn(ctx, "could not compile dependency",
-					slog.String("dependency", dep),
+					slog.String("dependency", dep.Path()),
 					slog.Any("error", err))
 			}
 		}
+
+		descriptor := protoutil.ProtoFromFileDescriptor(file)
 
 		// Only after dependencies add the file itself (if not already added)
 		if !processedFiles[fileName] {
@@ -197,13 +191,16 @@ func (c *Core) Generate(ctx context.Context, root, directory, descriptorSetOut s
 
 	// Process all files and their dependencies
 	for _, file := range res {
+		reflectFd := file.(protoreflect.FileDescriptor)
 		descriptor := protoutil.ProtoFromFileDescriptor(file)
 
 		// First add all dependencies of this file
-		for _, dep := range descriptor.Dependency {
+		for i := range reflectFd.Imports().Len() {
+			dep := reflectFd.Imports().Get(i)
+
 			if err := addFileWithDeps(dep); err != nil {
 				c.logger.Warn(ctx, "could not compile dependency",
-					slog.String("dependency", dep),
+					slog.String("dependency", dep.Path()),
 					slog.Any("error", err))
 			}
 		}
@@ -255,7 +252,7 @@ func (c *Core) Generate(ctx context.Context, root, directory, descriptorSetOut s
 			File: descriptorsToSave,
 		}
 
-		data, err := proto.Marshal(descriptorSet)
+		data, err := proto.MarshalOptions{Deterministic: true}.Marshal(descriptorSet)
 		if err != nil {
 			return fmt.Errorf("proto.Marshal: %w", err)
 		}


### PR DESCRIPTION
## Summary

This PR refactors the dependency resolution logic in the code generation pipeline to use `protoreflect.FileDescriptor` instead of recompiling files during traversal. It also introduces deterministic protobuf serialization for consistent output.

## Changes

-  **Refactor dependency processing**:  
  Replace filename-based recursion with direct use of `protoreflect.FileDescriptor`. This avoids redundant calls to `compiler.Compile` when resolving dependencies.

-  **Efficient import traversal**:  
  Use `file.Imports().Get(i)` to access dependencies directly from descriptor metadata, ensuring accurate and performant dependency graph construction.

-  **Deterministic output**:  
  Switch from `proto.Marshal` to `proto.MarshalOptions{Deterministic: true}` to ensure byte-stable serialization of descriptor sets.


## Why?

Previously, the code recompiled each file during dependency resolution just to extract its imports. Now we leverage the already available reflection data. 
The resulting binary descriptor set is compatible with reading through Envoy `http.grpc_json_transcoder` filter. 

## Impact

- No functional changes expected in generated output (behavior remains the same).
- Improved performance by eliminating redundant compilation steps.
- Better reliability and consistency in descriptor set generation.

## Testing

- Existing unit and integration tests pass.
- Verified correct ordering and completeness of dependencies in end-to-end generation flow.