### PR TITLE
fix: close lock file handles to prevent leaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+testdata/**/*.proto text eol=lf

--- a/internal/adapters/lock_file/lock_file.go
+++ b/internal/adapters/lock_file/lock_file.go
@@ -2,6 +2,7 @@ package lockfile
 
 import (
 	"bufio"
+	"fmt"
 	"strings"
 
 	"github.com/easyp-tech/easyp/internal/core"
@@ -21,7 +22,7 @@ type LockFile struct {
 	cache     map[string]fileInfo
 }
 
-func New(dirWalker core.DirWalker) *LockFile {
+func New(dirWalker core.DirWalker) (*LockFile, error) {
 	cache := make(map[string]fileInfo)
 
 	fp, err := dirWalker.Open(lockFileName)
@@ -42,11 +43,15 @@ func New(dirWalker core.DirWalker) *LockFile {
 			}
 			cache[parts[0]] = fileInfo
 		}
+
+		if err := fscanner.Err(); err != nil {
+			return nil, fmt.Errorf("scan %s: %w", lockFileName, err)
+		}
 	}
 
 	lockFile := &LockFile{
 		dirWalker: dirWalker,
 		cache:     cache,
 	}
-	return lockFile
+	return lockFile, nil
 }

--- a/internal/adapters/lock_file/lock_file.go
+++ b/internal/adapters/lock_file/lock_file.go
@@ -26,6 +26,8 @@ func New(dirWalker core.DirWalker) *LockFile {
 
 	fp, err := dirWalker.Open(lockFileName)
 	if err == nil {
+		defer func() { _ = fp.Close() }()
+
 		fscanner := bufio.NewScanner(fp)
 
 		for fscanner.Scan() {

--- a/internal/adapters/lock_file/write.go
+++ b/internal/adapters/lock_file/write.go
@@ -9,11 +9,16 @@ import (
 
 func (l *LockFile) Write(
 	moduleName string, revisionVersion string, installedPackageHash models.ModuleHash,
-) error {
+) (err error) {
 	fp, err := l.dirWalker.Create(lockFileName)
 	if err != nil {
 		return fmt.Errorf("l.dirWalker.Create: %w", err)
 	}
+	defer func() {
+		if closeErr := fp.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("fp.Close: %w", closeErr)
+		}
+	}()
 
 	fileInfo := fileInfo{
 		version: revisionVersion,
@@ -30,7 +35,9 @@ func (l *LockFile) Write(
 
 	for _, k := range keys {
 		r := fmt.Sprintf("%s %s %s\n", k, l.cache[k].version, l.cache[k].hash)
-		_, _ = fp.Write([]byte(r))
+		if _, err := fp.Write([]byte(r)); err != nil {
+			return fmt.Errorf("fp.Write: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/adapters/plugin/remote.go
+++ b/internal/adapters/plugin/remote.go
@@ -70,7 +70,14 @@ func (e *RemotePluginExecutor) Execute(ctx context.Context, plugin Info, request
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to gRPC server %s: %w", host, err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			e.logger.Warn(ctx, "failed to close gRPC connection",
+				slog.String("plugin", plugin.Source),
+				slog.Any("error", err),
+			)
+		}
+	}()
 
 	// Создаем gRPC клиент
 	client := plugingeneratorv1.NewServiceAPIClient(conn)
@@ -91,14 +98,6 @@ func (e *RemotePluginExecutor) Execute(ctx context.Context, plugin Info, request
 	resp, err := client.GenerateCode(ctxWithTimeout, grpcRequest)
 	if err != nil {
 		return nil, fmt.Errorf("gRPC call failed for plugin %s: %w", plugin.Source, err)
-	}
-
-	err = conn.Close()
-	if err != nil {
-		e.logger.Warn(ctx, "failed to close gRPC connection",
-			slog.String("plugin", plugin.Source),
-			slog.Any("error", err),
-		)
 	}
 
 	return resp.CodeGeneratorResponse, nil

--- a/internal/adapters/storage/get_install_dir_test.go
+++ b/internal/adapters/storage/get_install_dir_test.go
@@ -1,14 +1,14 @@
 package storage
 
 import (
-	"path"
+	"path/filepath"
 )
 
 func (s *storageSuite) Test_GetInstallDir() {
 	moduleName := getFakeModule().Name
 	version := getFakeRevision().Version
 
-	expectedResult := path.Join(s.rootDir, installedDir, moduleName, version)
+	expectedResult := filepath.Join(s.rootDir, installedDir, moduleName, version)
 
 	res := s.storage.GetInstallDir(moduleName, version)
 	s.Equal(expectedResult, res)

--- a/internal/adapters/storage/install_test.go
+++ b/internal/adapters/storage/install_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -183,9 +184,14 @@ func TestBuildInstallTree_AbsoluteSymlinkRejected(t *testing.T) {
 		Directories: []string{"proto"},
 	})
 
+	absTarget := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		absTarget = `C:\Windows\System32\drivers\etc\hosts`
+	}
+
 	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "proto"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "proto", "file.proto"), []byte("data"), 0644))
-	require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(srcDir, "proto", "bad.proto")))
+	require.NoError(t, os.Symlink(absTarget, filepath.Join(srcDir, "proto", "bad.proto")))
 
 	err := buildInstallTree(srcDir, dstDir, renamer)
 	require.Error(t, err)

--- a/internal/api/temporaly_helper.go
+++ b/internal/api/temporaly_helper.go
@@ -79,7 +79,11 @@ func buildCore(_ context.Context, log logger.Logger, cfg config.Config, dirWalke
 		return nil, fmt.Errorf("cfg.BuildLinterRules: %w", err)
 	}
 
-	lockFile := lockfile.New(dirWalker)
+	lockFile, err := lockfile.New(dirWalker)
+	if err != nil {
+		return nil, fmt.Errorf("lockfile.New: %w", err)
+	}
+
 	easypPath, err := getEasypPath(log)
 	if err != nil {
 		return nil, fmt.Errorf("getEasypPath: %w", err)


### PR DESCRIPTION
Fixed a few small bugs found while reading the code.

`LockFile.New` and `LockFile.Write` opened the lock file but never closed it,
leaking the handle every time those paths ran. `LockFile.Write` also silently
discarded `fp.Write` errors now they are returned to the caller.

`RemotePluginExecutor.Execute` closed the gRPC connection twice once via
`defer conn.Close()` and once explicitly at the end of the function. The
second close (the deferred one) silently returned an "already closed" error.
Removed the explicit close and moved the error log into the defer, so the
diagnostic is preserved without double-closing.

Note: `TestCore_BreakingCheck/broken` fails on Windows on `main` too due to
CRLF line endings shifting hardcoded byte offsets in test expectations.
Unrelated to this PR. Linux CI should be green.